### PR TITLE
fix(seeding): correct seed execution ordering to run RunOnce before R…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,16 @@
 *.userosscache
 *.sln.docstates
 
+# AI Related
+*.github/agents
+*.github/docs
+*.github/agents
+*.github/instructions
+*.github/plans
+*.github/skills
+*.github/AGENTS.md
+*.github/copilot-instructions.md
+
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 

--- a/DbReactor.Core.Tests/Seeding/EmbeddedSeedProviderTests.cs
+++ b/DbReactor.Core.Tests/Seeding/EmbeddedSeedProviderTests.cs
@@ -1,0 +1,192 @@
+using DbReactor.Core.Abstractions;
+using DbReactor.Core.Discovery;
+using DbReactor.Core.Seeding.Resolvers;
+using DbReactor.Core.Seeding.Strategies;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DbReactor.Core.Tests.Seeding;
+
+[TestFixture]
+public class EmbeddedSeedProviderTests
+{
+    private FolderStructureSeedStrategyResolver _resolver;
+    private Mock<Assembly> _mockAssembly;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _resolver = new FolderStructureSeedStrategyResolver();
+        _mockAssembly = new Mock<Assembly>();
+    }
+
+    [Test]
+    public async Task GetSeedsAsync_WhenResourceContainsRunAlways_ShouldResolveRunAlwaysStrategy()
+    {
+        // Given
+        var resourceName = "MyApp.Seeds.run-always.S001_Refresh.sql";
+        SetupEmbeddedResource(resourceName, "SELECT 1");
+
+        var provider = CreateProvider("MyApp.Seeds");
+
+        // When
+        var seeds = (await provider.GetSeedsAsync()).ToList();
+
+        // Then
+        using (new AssertionScope())
+        {
+            seeds.Should().HaveCount(1);
+            seeds[0].Strategy.Should().BeOfType<RunAlwaysSeedStrategy>();
+            seeds[0].Strategy.Name.Should().Be("RunAlways");
+        }
+    }
+
+    [Test]
+    public async Task GetSeedsAsync_WhenResourceContainsRunOnce_ShouldResolveRunOnceStrategy()
+    {
+        // Given
+        var resourceName = "MyApp.Seeds.run-once.S001_Init.sql";
+        SetupEmbeddedResource(resourceName, "CREATE TABLE Test (Id INT)");
+
+        var provider = CreateProvider("MyApp.Seeds");
+
+        // When
+        var seeds = (await provider.GetSeedsAsync()).ToList();
+
+        // Then
+        using (new AssertionScope())
+        {
+            seeds.Should().HaveCount(1);
+            seeds[0].Strategy.Should().BeOfType<RunOnceSeedStrategy>();
+            seeds[0].Strategy.Name.Should().Be("RunOnce");
+        }
+    }
+
+    [Test]
+    public async Task GetSeedsAsync_WhenResourceContainsRunIfChanged_ShouldResolveRunIfChangedStrategy()
+    {
+        // Given
+        var resourceName = "MyApp.Seeds.run-if-changed.S001_Lookups.sql";
+        SetupEmbeddedResource(resourceName, "INSERT INTO Lookups VALUES (1)");
+
+        var provider = CreateProvider("MyApp.Seeds");
+
+        // When
+        var seeds = (await provider.GetSeedsAsync()).ToList();
+
+        // Then
+        using (new AssertionScope())
+        {
+            seeds.Should().HaveCount(1);
+            seeds[0].Strategy.Should().BeOfType<RunIfChangedSeedStrategy>();
+            seeds[0].Strategy.Name.Should().Be("RunIfChanged");
+        }
+    }
+
+    [Test]
+    public async Task GetSeedsAsync_ShouldPreserveFullResourceNameAsSeedName()
+    {
+        // Given
+        var resourceName = "MyApp.Seeds.run-once.S001_Init.sql";
+        SetupEmbeddedResource(resourceName, "SELECT 1");
+
+        var provider = CreateProvider("MyApp.Seeds");
+
+        // When
+        var seeds = (await provider.GetSeedsAsync()).ToList();
+
+        // Then
+        seeds[0].Name.Should().Be(resourceName);
+    }
+
+    [Test]
+    public async Task GetSeedsAsync_WhenNoResourcesMatchNamespace_ShouldReturnEmpty()
+    {
+        // Given
+        _mockAssembly.Setup(a => a.GetManifestResourceNames())
+            .Returns(new[] { "OtherNamespace.Scripts.S001.sql" });
+
+        var provider = CreateProvider("MyApp.Seeds");
+
+        // When
+        var seeds = (await provider.GetSeedsAsync()).ToList();
+
+        // Then
+        seeds.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task GetSeedsAsync_WhenNoResolverMatches_ShouldUseFallbackStrategy()
+    {
+        // Given — resource name without strategy folder marker
+        var resourceName = "MyApp.Seeds.S001_Plain.sql";
+        SetupEmbeddedResource(resourceName, "SELECT 1");
+
+        var provider = CreateProvider("MyApp.Seeds");
+
+        // When
+        var seeds = (await provider.GetSeedsAsync()).ToList();
+
+        // Then — fallback is RunOnce by default
+        using (new AssertionScope())
+        {
+            seeds.Should().HaveCount(1);
+            seeds[0].Strategy.Should().BeOfType<RunOnceSeedStrategy>();
+        }
+    }
+
+    [Test]
+    public async Task GetSeedsAsync_WhenMultipleResources_ShouldDiscoverAllWithCorrectStrategies()
+    {
+        // Given
+        var resources = new[]
+        {
+            "MyApp.Seeds.run-once.S001_Init.sql",
+            "MyApp.Seeds.run-always.S002_Refresh.sql",
+            "MyApp.Seeds.run-if-changed.S003_Lookups.sql",
+        };
+
+        foreach (var resource in resources)
+        {
+            SetupEmbeddedResource(resource, $"-- {resource}");
+        }
+
+        // Re-setup GetManifestResourceNames to return all resources
+        _mockAssembly.Setup(a => a.GetManifestResourceNames()).Returns(resources);
+
+        var provider = CreateProvider("MyApp.Seeds");
+
+        // When
+        var seeds = (await provider.GetSeedsAsync()).ToList();
+
+        // Then
+        using (new AssertionScope())
+        {
+            seeds.Should().HaveCount(3);
+            seeds.Should().Contain(s => s.Strategy is RunOnceSeedStrategy);
+            seeds.Should().Contain(s => s.Strategy is RunAlwaysSeedStrategy);
+            seeds.Should().Contain(s => s.Strategy is RunIfChangedSeedStrategy);
+        }
+    }
+
+    private void SetupEmbeddedResource(string resourceName, string content)
+    {
+        var stream = new MemoryStream(Encoding.UTF8.GetBytes(content));
+        _mockAssembly.Setup(a => a.GetManifestResourceNames())
+            .Returns(new[] { resourceName });
+        _mockAssembly.Setup(a => a.GetManifestResourceStream(resourceName))
+            .Returns(stream);
+    }
+
+    private EmbeddedSeedProvider CreateProvider(string resourceNamespace)
+    {
+        return new EmbeddedSeedProvider(
+            _mockAssembly.Object,
+            resourceNamespace,
+            new ISeedStrategyResolver[] { _resolver });
+    }
+}

--- a/DbReactor.Core.Tests/Seeding/FileSystemSeedProviderTests.cs
+++ b/DbReactor.Core.Tests/Seeding/FileSystemSeedProviderTests.cs
@@ -1,0 +1,193 @@
+using DbReactor.Core.Abstractions;
+using DbReactor.Core.Discovery;
+using DbReactor.Core.Seeding.Resolvers;
+using DbReactor.Core.Seeding.Strategies;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DbReactor.Core.Tests.Seeding;
+
+[TestFixture]
+public class FileSystemSeedProviderTests
+{
+    private string _testDirectory;
+    private FolderStructureSeedStrategyResolver _resolver;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _testDirectory = Path.Combine(Path.GetTempPath(), "DbReactor_Tests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_testDirectory);
+        _resolver = new FolderStructureSeedStrategyResolver();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_testDirectory))
+        {
+            Directory.Delete(_testDirectory, true);
+        }
+    }
+
+    [Test]
+    public async Task GetSeedsAsync_WhenRunOnceFolderContainsScripts_ShouldAssignRunOnceStrategy()
+    {
+        // Given
+        var runOnceDir = Path.Combine(_testDirectory, "run-once");
+        Directory.CreateDirectory(runOnceDir);
+        File.WriteAllText(Path.Combine(runOnceDir, "S001_CreateUsers.sql"), "CREATE TABLE Users (Id INT)");
+
+        var provider = CreateProvider();
+
+        // When
+        var seeds = (await provider.GetSeedsAsync()).ToList();
+
+        // Then
+        using (new AssertionScope())
+        {
+            seeds.Should().HaveCount(1);
+            seeds[0].Strategy.Should().BeOfType<RunOnceSeedStrategy>();
+            seeds[0].Strategy.Name.Should().Be("RunOnce");
+        }
+    }
+
+    [Test]
+    public async Task GetSeedsAsync_WhenRunAlwaysFolderContainsScripts_ShouldAssignRunAlwaysStrategy()
+    {
+        // Given
+        var runAlwaysDir = Path.Combine(_testDirectory, "run-always");
+        Directory.CreateDirectory(runAlwaysDir);
+        File.WriteAllText(Path.Combine(runAlwaysDir, "S001_RefreshViews.sql"), "EXEC sp_refreshview 'vw_Test'");
+
+        var provider = CreateProvider();
+
+        // When
+        var seeds = (await provider.GetSeedsAsync()).ToList();
+
+        // Then
+        using (new AssertionScope())
+        {
+            seeds.Should().HaveCount(1);
+            seeds[0].Strategy.Should().BeOfType<RunAlwaysSeedStrategy>();
+            seeds[0].Strategy.Name.Should().Be("RunAlways");
+        }
+    }
+
+    [Test]
+    public async Task GetSeedsAsync_WhenRunIfChangedFolderContainsScripts_ShouldAssignRunIfChangedStrategy()
+    {
+        // Given
+        var runIfChangedDir = Path.Combine(_testDirectory, "run-if-changed");
+        Directory.CreateDirectory(runIfChangedDir);
+        File.WriteAllText(Path.Combine(runIfChangedDir, "S001_SeedLookups.sql"), "INSERT INTO Lookups VALUES (1, 'Active')");
+
+        var provider = CreateProvider();
+
+        // When
+        var seeds = (await provider.GetSeedsAsync()).ToList();
+
+        // Then
+        using (new AssertionScope())
+        {
+            seeds.Should().HaveCount(1);
+            seeds[0].Strategy.Should().BeOfType<RunIfChangedSeedStrategy>();
+            seeds[0].Strategy.Name.Should().Be("RunIfChanged");
+        }
+    }
+
+    [Test]
+    public async Task GetSeedsAsync_ShouldPreserveShortFilenameAsName()
+    {
+        // Given
+        var runOnceDir = Path.Combine(_testDirectory, "run-once");
+        Directory.CreateDirectory(runOnceDir);
+        File.WriteAllText(Path.Combine(runOnceDir, "S001_InsertDefaults.sql"), "INSERT INTO Config DEFAULT VALUES");
+
+        var provider = CreateProvider();
+
+        // When
+        var seeds = (await provider.GetSeedsAsync()).ToList();
+
+        // Then
+        seeds[0].Name.Should().Be("S001_InsertDefaults");
+    }
+
+    [Test]
+    public async Task GetSeedsAsync_WhenDirectoryDoesNotExist_ShouldReturnEmptyCollection()
+    {
+        // Given
+        var nonExistentPath = Path.Combine(_testDirectory, "does-not-exist");
+        var provider = new FileSystemSeedProvider(
+            nonExistentPath,
+            new ISeedStrategyResolver[] { _resolver });
+
+        // When
+        var seeds = (await provider.GetSeedsAsync()).ToList();
+
+        // Then
+        seeds.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task GetSeedsAsync_WhenMultipleFolders_ShouldDiscoverAllWithCorrectStrategies()
+    {
+        // Given
+        var runOnceDir = Path.Combine(_testDirectory, "run-once");
+        var runAlwaysDir = Path.Combine(_testDirectory, "run-always");
+        var runIfChangedDir = Path.Combine(_testDirectory, "run-if-changed");
+
+        Directory.CreateDirectory(runOnceDir);
+        Directory.CreateDirectory(runAlwaysDir);
+        Directory.CreateDirectory(runIfChangedDir);
+
+        File.WriteAllText(Path.Combine(runOnceDir, "S001_Init.sql"), "SELECT 1");
+        File.WriteAllText(Path.Combine(runAlwaysDir, "S002_Refresh.sql"), "SELECT 2");
+        File.WriteAllText(Path.Combine(runIfChangedDir, "S003_Lookups.sql"), "SELECT 3");
+
+        var provider = CreateProvider();
+
+        // When
+        var seeds = (await provider.GetSeedsAsync()).ToList();
+
+        // Then
+        using (new AssertionScope())
+        {
+            seeds.Should().HaveCount(3);
+            seeds.Should().Contain(s => s.Strategy is RunAlwaysSeedStrategy);
+            seeds.Should().Contain(s => s.Strategy is RunIfChangedSeedStrategy);
+            seeds.Should().Contain(s => s.Strategy is RunOnceSeedStrategy);
+        }
+    }
+
+    [Test]
+    public async Task GetSeedsAsync_WhenNoResolverMatches_ShouldUseFallbackStrategy()
+    {
+        // Given — script in a folder that doesn't match any strategy resolver
+        var otherDir = Path.Combine(_testDirectory, "other");
+        Directory.CreateDirectory(otherDir);
+        File.WriteAllText(Path.Combine(otherDir, "S001_Something.sql"), "SELECT 1");
+
+        var provider = CreateProvider();
+
+        // When
+        var seeds = (await provider.GetSeedsAsync()).ToList();
+
+        // Then — fallback is RunOnce by default
+        using (new AssertionScope())
+        {
+            seeds.Should().HaveCount(1);
+            seeds[0].Strategy.Should().BeOfType<RunOnceSeedStrategy>();
+        }
+    }
+
+    private FileSystemSeedProvider CreateProvider()
+    {
+        return new FileSystemSeedProvider(
+            _testDirectory,
+            new ISeedStrategyResolver[] { _resolver });
+    }
+}

--- a/DbReactor.Core.Tests/Seeding/SeedOrchestratorOrderingTests.cs
+++ b/DbReactor.Core.Tests/Seeding/SeedOrchestratorOrderingTests.cs
@@ -1,0 +1,263 @@
+using DbReactor.Core.Abstractions;
+using DbReactor.Core.Configuration;
+using DbReactor.Core.Constants;
+using DbReactor.Core.Execution;
+using DbReactor.Core.Models;
+using DbReactor.Core.Services;
+using DbReactor.Core.Seeding.Strategies;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DbReactor.Core.Tests.Seeding;
+
+[TestFixture]
+public class SeedOrchestratorOrderingTests
+{
+    private Mock<IConnectionManager> _mockConnectionManager;
+    private Mock<IScriptExecutor> _mockScriptExecutor;
+    private Mock<ISeedJournal> _mockSeedJournal;
+    private DbReactorConfiguration _configuration;
+    private List<string> _executionOrder;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockConnectionManager = new Mock<IConnectionManager>();
+        _mockScriptExecutor = new Mock<IScriptExecutor>();
+        _mockSeedJournal = new Mock<ISeedJournal>();
+        _executionOrder = new List<string>();
+
+        _configuration = new DbReactorConfiguration
+        {
+            ConnectionManager = _mockConnectionManager.Object,
+            ScriptExecutor = _mockScriptExecutor.Object,
+            EnableVariables = false,
+            Variables = new Dictionary<string, string>()
+        };
+
+        _mockSeedJournal.Setup(j => j.EnsureTableExistsAsync(It.IsAny<IConnectionManager>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _mockSeedJournal.Setup(j => j.RecordExecutionAsync(It.IsAny<ISeed>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Track execution order via the script executor
+        _mockScriptExecutor.Setup(e => e.ExecuteAsync(It.IsAny<IScript>(), It.IsAny<IConnectionManager>(), It.IsAny<CancellationToken>()))
+            .Callback<IScript, IConnectionManager, CancellationToken>((script, _, _) => _executionOrder.Add(script.Name))
+            .ReturnsAsync(new MigrationResult { Successful = true });
+    }
+
+    [Test]
+    public async Task ExecuteSeedsAsync_WhenMixedStrategies_ShouldExecuteInPriorityOrder()
+    {
+        // Given
+        var seeds = new List<ISeed>
+        {
+            CreateSeed("RunAlways_Seed1", new RunAlwaysSeedStrategy()),
+            CreateSeed("RunOnce_Seed1", new RunOnceSeedStrategy()),
+            CreateSeed("RunIfChanged_Seed1", new RunIfChangedSeedStrategy()),
+        };
+
+        SetupAllSeedsShouldExecute(seeds);
+        var orchestrator = CreateOrchestrator(seeds);
+
+        // When
+        var result = await orchestrator.ExecuteSeedsAsync();
+
+        // Then
+        using (new AssertionScope())
+        {
+            result.Successful.Should().BeTrue();
+            _executionOrder.Should().HaveCount(3);
+            _executionOrder[0].Should().Be("RunOnce_Seed1");
+            _executionOrder[1].Should().Be("RunIfChanged_Seed1");
+            _executionOrder[2].Should().Be("RunAlways_Seed1");
+        }
+    }
+
+    [Test]
+    public async Task ExecuteSeedsAsync_WhenAllRunOnceBeforeAnyRunAlways_ShouldMaintainOrder()
+    {
+        // Given
+        var seeds = new List<ISeed>
+        {
+            CreateSeed("RunAlways_A", new RunAlwaysSeedStrategy()),
+            CreateSeed("RunAlways_B", new RunAlwaysSeedStrategy()),
+            CreateSeed("RunOnce_A", new RunOnceSeedStrategy()),
+            CreateSeed("RunOnce_B", new RunOnceSeedStrategy()),
+        };
+
+        SetupAllSeedsShouldExecute(seeds);
+        var orchestrator = CreateOrchestrator(seeds);
+
+        // When
+        var result = await orchestrator.ExecuteSeedsAsync();
+
+        // Then
+        using (new AssertionScope())
+        {
+            result.Successful.Should().BeTrue();
+            _executionOrder.Should().HaveCount(4);
+
+            // All RunOnce seeds must execute before any RunAlways seed
+            var runOnceIndices = _executionOrder.Select((name, idx) => new { name, idx })
+                .Where(x => x.name.StartsWith("RunOnce")).Select(x => x.idx);
+            var runAlwaysIndices = _executionOrder.Select((name, idx) => new { name, idx })
+                .Where(x => x.name.StartsWith("RunAlways")).Select(x => x.idx);
+
+            runOnceIndices.Max().Should().BeLessThan(runAlwaysIndices.Min());
+        }
+    }
+
+    [Test]
+    public async Task ExecuteSeedsAsync_WhenSameStrategy_ShouldPreserveDiscoveryOrder()
+    {
+        // Given — seeds discovered in A, B, C order
+        var seeds = new List<ISeed>
+        {
+            CreateSeed("Seed_A", new RunAlwaysSeedStrategy()),
+            CreateSeed("Seed_B", new RunAlwaysSeedStrategy()),
+            CreateSeed("Seed_C", new RunAlwaysSeedStrategy()),
+        };
+
+        SetupAllSeedsShouldExecute(seeds);
+        var orchestrator = CreateOrchestrator(seeds);
+
+        // When
+        var result = await orchestrator.ExecuteSeedsAsync();
+
+        // Then — stable sort preserves discovery order within same priority
+        using (new AssertionScope())
+        {
+            result.Successful.Should().BeTrue();
+            _executionOrder.Should().ContainInOrder("Seed_A", "Seed_B", "Seed_C");
+        }
+    }
+
+    [Test]
+    public async Task ExecuteSeedsAsync_WhenSingleStrategyType_ShouldExecuteCorrectly()
+    {
+        // Given
+        var seeds = new List<ISeed>
+        {
+            CreateSeed("OnlySeed1", new RunOnceSeedStrategy()),
+            CreateSeed("OnlySeed2", new RunOnceSeedStrategy()),
+        };
+
+        SetupAllSeedsShouldExecute(seeds);
+        var orchestrator = CreateOrchestrator(seeds);
+
+        // When
+        var result = await orchestrator.ExecuteSeedsAsync();
+
+        // Then
+        using (new AssertionScope())
+        {
+            result.Successful.Should().BeTrue();
+            _executionOrder.Should().HaveCount(2);
+            _executionOrder.Should().ContainInOrder("OnlySeed1", "OnlySeed2");
+        }
+    }
+
+    [Test]
+    public async Task ExecuteSeedsAsync_WhenNoSeeds_ShouldReturnSuccessWithoutError()
+    {
+        // Given — empty seed list
+        var seeds = new List<ISeed>();
+        var orchestrator = CreateOrchestrator(seeds);
+
+        // When
+        var result = await orchestrator.ExecuteSeedsAsync();
+
+        // Then
+        using (new AssertionScope())
+        {
+            result.Successful.Should().BeTrue();
+            result.Scripts.Should().BeEmpty();
+        }
+    }
+
+    [Test]
+    public async Task ExecuteSeedsAsync_WhenMixedWithStableSort_ShouldPreserveDiscoveryWithinSamePriority()
+    {
+        // Given — interleaved strategies with multiple seeds each
+        var seeds = new List<ISeed>
+        {
+            CreateSeed("RunAlways_First", new RunAlwaysSeedStrategy()),
+            CreateSeed("RunOnce_First", new RunOnceSeedStrategy()),
+            CreateSeed("RunIfChanged_First", new RunIfChangedSeedStrategy()),
+            CreateSeed("RunOnce_Second", new RunOnceSeedStrategy()),
+            CreateSeed("RunAlways_Second", new RunAlwaysSeedStrategy()),
+            CreateSeed("RunIfChanged_Second", new RunIfChangedSeedStrategy()),
+        };
+
+        SetupAllSeedsShouldExecute(seeds);
+        var orchestrator = CreateOrchestrator(seeds);
+
+        // When
+        var result = await orchestrator.ExecuteSeedsAsync();
+
+        // Then
+        using (new AssertionScope())
+        {
+            result.Successful.Should().BeTrue();
+            _executionOrder.Should().HaveCount(6);
+
+            // RunOnce seeds first, in discovery order
+            _executionOrder[0].Should().Be("RunOnce_First");
+            _executionOrder[1].Should().Be("RunOnce_Second");
+
+            // RunIfChanged seeds second, in discovery order
+            _executionOrder[2].Should().Be("RunIfChanged_First");
+            _executionOrder[3].Should().Be("RunIfChanged_Second");
+
+            // RunAlways seeds last, in discovery order
+            _executionOrder[4].Should().Be("RunAlways_First");
+            _executionOrder[5].Should().Be("RunAlways_Second");
+        }
+    }
+
+    private ISeed CreateSeed(string name, ISeedExecutionStrategy strategy)
+    {
+        var mockScript = new Mock<IScript>();
+        mockScript.Setup(s => s.Name).Returns(name);
+        mockScript.Setup(s => s.Script).Returns($"-- {name}");
+        mockScript.Setup(s => s.Hash).Returns($"hash_{name}");
+
+        return new Seed(name, mockScript.Object, strategy, $"hash_{name}");
+    }
+
+    private void SetupAllSeedsShouldExecute(IEnumerable<ISeed> seeds)
+    {
+        foreach (var seed in seeds)
+        {
+            // RunAlways always returns true; for RunOnce/RunIfChanged, mock the journal
+            _mockSeedJournal.Setup(j => j.HasBeenExecutedAsync(It.Is<ISeed>(s => s.Name == seed.Name), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(false);
+            _mockSeedJournal.Setup(j => j.GetLastExecutedHashAsync(seed.Name, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((string?)null);
+        }
+    }
+
+    private SeedOrchestrator CreateOrchestrator(IEnumerable<ISeed> seeds)
+    {
+        var mockSeedProvider = new Mock<ISeedScriptProvider>();
+        mockSeedProvider.Setup(p => p.GetSeedsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(seeds);
+
+        var discoveryService = new SeedDiscoveryService(
+            seedProviders: new[] { mockSeedProvider.Object });
+
+        var variableService = new VariableSubstitutionService();
+
+        return new SeedOrchestrator(
+            _configuration,
+            discoveryService,
+            _mockSeedJournal.Object,
+            _mockScriptExecutor.Object,
+            variableService);
+    }
+}

--- a/DbReactor.Core.Tests/Seeding/SeedStrategyPriorityTests.cs
+++ b/DbReactor.Core.Tests/Seeding/SeedStrategyPriorityTests.cs
@@ -1,0 +1,123 @@
+using DbReactor.Core.Constants;
+
+namespace DbReactor.Core.Tests.Seeding;
+
+[TestFixture]
+public class SeedStrategyPriorityTests
+{
+    [Test]
+    public void GetPriority_WhenStrategyIsRunOnce_ShouldReturn1()
+    {
+        // When
+        var priority = SeedStrategyPriority.GetPriority(DbReactorConstants.SeedStrategies.RunOnce);
+
+        // Then
+        priority.Should().Be(1);
+    }
+
+    [Test]
+    public void GetPriority_WhenStrategyIsRunIfChanged_ShouldReturn2()
+    {
+        // When
+        var priority = SeedStrategyPriority.GetPriority(DbReactorConstants.SeedStrategies.RunIfChanged);
+
+        // Then
+        priority.Should().Be(2);
+    }
+
+    [Test]
+    public void GetPriority_WhenStrategyIsRunAlways_ShouldReturn3()
+    {
+        // When
+        var priority = SeedStrategyPriority.GetPriority(DbReactorConstants.SeedStrategies.RunAlways);
+
+        // Then
+        priority.Should().Be(3);
+    }
+
+    [Test]
+    public void GetPriority_WhenStrategyIsUnknown_ShouldReturn99()
+    {
+        // When
+        var priority = SeedStrategyPriority.GetPriority("CustomStrategy");
+
+        // Then
+        priority.Should().Be(99);
+    }
+
+    [Test]
+    public void GetPriority_WhenStrategyIsEmpty_ShouldReturn99()
+    {
+        // When
+        var priority = SeedStrategyPriority.GetPriority("");
+
+        // Then
+        priority.Should().Be(99);
+    }
+
+    [TestCase("runonce")]
+    [TestCase("RUNONCE")]
+    [TestCase("runOnce")]
+    public void GetPriority_WhenStrategyHasDifferentCasing_ShouldReturn99(string strategyName)
+    {
+        // Strategy matching is case-sensitive (uses exact string comparison)
+        // When
+        var priority = SeedStrategyPriority.GetPriority(strategyName);
+
+        // Then
+        priority.Should().Be(99);
+    }
+
+    [Test]
+    public void GetPriority_RunOncePriorityShouldBeLessThanRunIfChanged()
+    {
+        // When
+        var runOncePriority = SeedStrategyPriority.GetPriority(DbReactorConstants.SeedStrategies.RunOnce);
+        var runIfChangedPriority = SeedStrategyPriority.GetPriority(DbReactorConstants.SeedStrategies.RunIfChanged);
+
+        // Then
+        runOncePriority.Should().BeLessThan(runIfChangedPriority);
+    }
+
+    [Test]
+    public void GetPriority_RunIfChangedPriorityShouldBeLessThanRunAlways()
+    {
+        // When
+        var runIfChangedPriority = SeedStrategyPriority.GetPriority(DbReactorConstants.SeedStrategies.RunIfChanged);
+        var runAlwaysPriority = SeedStrategyPriority.GetPriority(DbReactorConstants.SeedStrategies.RunAlways);
+
+        // Then
+        runIfChangedPriority.Should().BeLessThan(runAlwaysPriority);
+    }
+
+    [Test]
+    public void GetPriority_AllKnownStrategiesShouldBeLessThanDefault()
+    {
+        // When
+        var runOncePriority = SeedStrategyPriority.GetPriority(DbReactorConstants.SeedStrategies.RunOnce);
+        var runIfChangedPriority = SeedStrategyPriority.GetPriority(DbReactorConstants.SeedStrategies.RunIfChanged);
+        var runAlwaysPriority = SeedStrategyPriority.GetPriority(DbReactorConstants.SeedStrategies.RunAlways);
+        var defaultPriority = SeedStrategyPriority.GetPriority("Unknown");
+
+        // Then
+        using (new AssertionScope())
+        {
+            runOncePriority.Should().BeLessThan(defaultPriority);
+            runIfChangedPriority.Should().BeLessThan(defaultPriority);
+            runAlwaysPriority.Should().BeLessThan(defaultPriority);
+        }
+    }
+
+    [Test]
+    public void Constants_ShouldHaveExpectedValues()
+    {
+        // Then
+        using (new AssertionScope())
+        {
+            SeedStrategyPriority.RunOnce.Should().Be(1);
+            SeedStrategyPriority.RunIfChanged.Should().Be(2);
+            SeedStrategyPriority.RunAlways.Should().Be(3);
+            SeedStrategyPriority.Default.Should().Be(99);
+        }
+    }
+}

--- a/DbReactor.Core/Abstractions/ISeedScriptProvider.cs
+++ b/DbReactor.Core/Abstractions/ISeedScriptProvider.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DbReactor.Core.Abstractions
+{
+    /// <summary>
+    /// Provides seed scripts with strategy already resolved at discovery time.
+    /// Unlike IScriptProvider (which returns raw IScript), this provider returns
+    /// fully-formed ISeed instances with correct strategy resolution using full path context.
+    /// </summary>
+    public interface ISeedScriptProvider
+    {
+        /// <summary>
+        /// Gets seeds with strategy resolved at discovery time
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Collection of seeds with strategy already resolved</returns>
+        Task<IEnumerable<ISeed>> GetSeedsAsync(CancellationToken cancellationToken = default);
+    }
+}

--- a/DbReactor.Core/Constants/SeedStrategyPriority.cs
+++ b/DbReactor.Core/Constants/SeedStrategyPriority.cs
@@ -1,0 +1,47 @@
+namespace DbReactor.Core.Constants
+{
+    /// <summary>
+    /// Defines execution priority for seed strategies.
+    /// Lower values execute first.
+    /// </summary>
+    public static class SeedStrategyPriority
+    {
+        /// <summary>
+        /// RunOnce seeds execute first (priority 1)
+        /// </summary>
+        public const int RunOnce = 1;
+
+        /// <summary>
+        /// RunIfChanged seeds execute second (priority 2)
+        /// </summary>
+        public const int RunIfChanged = 2;
+
+        /// <summary>
+        /// RunAlways seeds execute last (priority 3)
+        /// </summary>
+        public const int RunAlways = 3;
+
+        /// <summary>
+        /// Default priority for unknown strategies
+        /// </summary>
+        public const int Default = 99;
+
+        /// <summary>
+        /// Gets the execution priority for a given strategy name.
+        /// Lower values execute first.
+        /// </summary>
+        /// <param name="strategyName">The strategy name from ISeedExecutionStrategy.Name</param>
+        /// <returns>Priority integer for sorting</returns>
+        public static int GetPriority(string strategyName)
+        {
+            if (strategyName == DbReactorConstants.SeedStrategies.RunOnce)
+                return RunOnce;
+            if (strategyName == DbReactorConstants.SeedStrategies.RunIfChanged)
+                return RunIfChanged;
+            if (strategyName == DbReactorConstants.SeedStrategies.RunAlways)
+                return RunAlways;
+
+            return Default;
+        }
+    }
+}

--- a/DbReactor.Core/Discovery/EmbeddedSeedProvider.cs
+++ b/DbReactor.Core/Discovery/EmbeddedSeedProvider.cs
@@ -1,0 +1,96 @@
+using DbReactor.Core.Abstractions;
+using DbReactor.Core.Models;
+using DbReactor.Core.Models.Scripts;
+using DbReactor.Core.Seeding.Strategies;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DbReactor.Core.Discovery
+{
+    /// <summary>
+    /// Discovers embedded resource seed scripts with strategy resolved at discovery time.
+    /// Passes the full resource name to strategy resolvers so folder-based resolution works correctly.
+    /// </summary>
+    public class EmbeddedSeedProvider : ISeedScriptProvider
+    {
+        private readonly Assembly _assembly;
+        private readonly string _resourceNamespace;
+        private readonly string _scriptSuffix;
+        private readonly IEnumerable<ISeedStrategyResolver> _strategyResolvers;
+        private readonly ISeedExecutionStrategy _fallbackStrategy;
+
+        /// <summary>
+        /// Initializes a new instance of EmbeddedSeedProvider
+        /// </summary>
+        /// <param name="assembly">Assembly containing embedded seed resources</param>
+        /// <param name="resourceNamespace">Namespace prefix to filter resources</param>
+        /// <param name="strategyResolvers">Strategy resolvers to apply using full resource name</param>
+        /// <param name="scriptSuffix">File extension filter (default: .sql)</param>
+        /// <param name="fallbackStrategy">Fallback strategy when no resolver matches</param>
+        public EmbeddedSeedProvider(
+            Assembly assembly,
+            string resourceNamespace,
+            IEnumerable<ISeedStrategyResolver> strategyResolvers,
+            string scriptSuffix = ".sql",
+            ISeedExecutionStrategy fallbackStrategy = null)
+        {
+            _assembly = assembly ?? throw new ArgumentNullException(nameof(assembly));
+            _resourceNamespace = resourceNamespace ?? throw new ArgumentNullException(nameof(resourceNamespace));
+            _strategyResolvers = strategyResolvers ?? Enumerable.Empty<ISeedStrategyResolver>();
+            _scriptSuffix = scriptSuffix ?? ".sql";
+            _fallbackStrategy = fallbackStrategy ?? new RunOnceSeedStrategy();
+        }
+
+        /// <summary>
+        /// Gets seeds from embedded resources with strategy resolved using the full resource name
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Collection of seeds with strategy resolved</returns>
+        public Task<IEnumerable<ISeed>> GetSeedsAsync(CancellationToken cancellationToken = default)
+        {
+            IEnumerable<ISeed> seeds = _assembly.GetManifestResourceNames()
+                .Where(r => r.StartsWith(_resourceNamespace, StringComparison.Ordinal)
+                    && r.EndsWith(_scriptSuffix, StringComparison.OrdinalIgnoreCase))
+                .OrderBy(r => r)
+                .Select(resourceName =>
+                {
+                    try
+                    {
+                        var script = new EmbeddedScript(_assembly, resourceName);
+                        if (string.IsNullOrEmpty(script.Script))
+                            return null;
+
+                        // Pass full resource name to strategy resolvers for folder-based resolution
+                        var strategy = ResolveStrategy(script, resourceName);
+
+                        // Keep resource name as seed name (journal-compatible with existing EmbeddedScriptProvider behavior)
+                        return new Seed(resourceName, script, strategy, script.Hash);
+                    }
+                    catch (Exception)
+                    {
+                        // Skip unreadable resources (matches EmbeddedScriptProvider behavior)
+                        return null;
+                    }
+                })
+                .Where(s => s != null);
+
+            return Task.FromResult(seeds);
+        }
+
+        private ISeedExecutionStrategy ResolveStrategy(IScript script, string resourceName)
+        {
+            foreach (var resolver in _strategyResolvers)
+            {
+                var strategy = resolver.ResolveStrategy(script, resourceName);
+                if (strategy != null)
+                    return strategy;
+            }
+
+            return _fallbackStrategy;
+        }
+    }
+}

--- a/DbReactor.Core/Discovery/FileSystemSeedProvider.cs
+++ b/DbReactor.Core/Discovery/FileSystemSeedProvider.cs
@@ -1,0 +1,120 @@
+using DbReactor.Core.Abstractions;
+using DbReactor.Core.Models;
+using DbReactor.Core.Models.Scripts;
+using DbReactor.Core.Seeding.Strategies;
+using DbReactor.Core.Utilities;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DbReactor.Core.Discovery
+{
+    /// <summary>
+    /// Discovers seed scripts from the file system with strategy resolved at discovery time.
+    /// Passes the full relative path to strategy resolvers so folder-based resolution works correctly.
+    /// </summary>
+    public class FileSystemSeedProvider : ISeedScriptProvider
+    {
+        private readonly string _directoryPath;
+        private readonly string _fileExtension;
+        private readonly IEnumerable<ISeedStrategyResolver> _strategyResolvers;
+        private readonly ISeedExecutionStrategy _fallbackStrategy;
+
+        /// <summary>
+        /// Initializes a new instance of FileSystemSeedProvider
+        /// </summary>
+        /// <param name="directoryPath">Root directory to search for seed scripts</param>
+        /// <param name="strategyResolvers">Strategy resolvers to apply using full relative path</param>
+        /// <param name="fileExtension">File extension filter (default: .sql)</param>
+        /// <param name="fallbackStrategy">Fallback strategy when no resolver matches</param>
+        public FileSystemSeedProvider(
+            string directoryPath,
+            IEnumerable<ISeedStrategyResolver> strategyResolvers,
+            string fileExtension = ".sql",
+            ISeedExecutionStrategy fallbackStrategy = null)
+        {
+            if (string.IsNullOrEmpty(directoryPath))
+                throw new ArgumentException("Directory path cannot be null or empty", nameof(directoryPath));
+
+            _directoryPath = directoryPath;
+            _strategyResolvers = strategyResolvers ?? Enumerable.Empty<ISeedStrategyResolver>();
+            _fileExtension = fileExtension ?? ".sql";
+            _fallbackStrategy = fallbackStrategy ?? new RunOnceSeedStrategy();
+        }
+
+        /// <summary>
+        /// Gets seeds from the file system with strategy resolved using the full relative path
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Collection of seeds with strategy resolved</returns>
+        public async Task<IEnumerable<ISeed>> GetSeedsAsync(CancellationToken cancellationToken = default)
+        {
+            if (!Directory.Exists(_directoryPath))
+            {
+                return Enumerable.Empty<ISeed>();
+            }
+
+            var pattern = "*" + _fileExtension;
+            // Sort by full path to maintain subdirectory ordering (differs from FileSystemScriptProvider which sorts by filename only)
+            var scriptFiles = Directory.GetFiles(_directoryPath, pattern, SearchOption.AllDirectories)
+                .OrderBy(f => f, StringComparer.OrdinalIgnoreCase);
+
+            var seeds = new List<ISeed>();
+            foreach (var filePath in scriptFiles)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var seed = await CreateSeedFromFileAsync(filePath, cancellationToken);
+                seeds.Add(seed);
+            }
+
+            return seeds;
+        }
+
+        private async Task<ISeed> CreateSeedFromFileAsync(string filePath, CancellationToken cancellationToken)
+        {
+            var content = await Task.Run(() => File.ReadAllText(filePath), cancellationToken);
+            var fileName = Path.GetFileNameWithoutExtension(filePath);
+
+            // Use short filename as the script/seed name (journal-compatible)
+            var script = new GenericScript(fileName, content);
+
+            // Use full relative path for strategy resolution so folder-based resolvers work
+            var relativePath = GetRelativePath(_directoryPath, filePath);
+            var strategy = ResolveStrategy(script, relativePath);
+
+            return new Seed(fileName, script, strategy, script.Hash);
+        }
+
+        private ISeedExecutionStrategy ResolveStrategy(IScript script, string relativePath)
+        {
+            foreach (var resolver in _strategyResolvers)
+            {
+                var strategy = resolver.ResolveStrategy(script, relativePath);
+                if (strategy != null)
+                    return strategy;
+            }
+
+            return _fallbackStrategy;
+        }
+
+        // Uses Uri.MakeRelativeUri because Path.GetRelativePath is not available on netstandard2.0
+        private static string GetRelativePath(string basePath, string fullPath)
+        {
+            var baseUri = new Uri(EnsureTrailingSlash(Path.GetFullPath(basePath)));
+            var fullUri = new Uri(Path.GetFullPath(fullPath));
+            return Uri.UnescapeDataString(baseUri.MakeRelativeUri(fullUri).ToString())
+                .Replace('/', Path.DirectorySeparatorChar);
+        }
+
+        private static string EnsureTrailingSlash(string path)
+        {
+            return path.EndsWith(Path.DirectorySeparatorChar.ToString())
+                ? path
+                : path + Path.DirectorySeparatorChar;
+        }
+    }
+}

--- a/DbReactor.Core/README.md
+++ b/DbReactor.Core/README.md
@@ -314,7 +314,13 @@ var config = new DbReactorConfiguration()
 
 ### Seeding Strategies
 
-Seeds use execution strategies to determine when they should run:
+Seeds use execution strategies to determine when they should run. The `SeedOrchestrator` executes seeds in a fixed priority order:
+
+1. **RunOnce** (priority 1) — Initial data setup. Executes first because other seeds may depend on this base data.
+2. **RunIfChanged** (priority 2) — Conditional updates. Executes second because it assumes base data exists.
+3. **RunAlways** (priority 3) — Refresh/recalculation. Executes last because it operates on fully-established state.
+
+Within the same priority level, seeds execute in discovery order (alphabetical by name).
 
 #### RunOnce (Default)
 Executes only once, tracked in the seed journal:

--- a/DbReactor.Core/Services/SeedDiscoveryService.cs
+++ b/DbReactor.Core/Services/SeedDiscoveryService.cs
@@ -16,6 +16,7 @@ namespace DbReactor.Core.Services
     public class SeedDiscoveryService
     {
         private readonly IEnumerable<IScriptProvider> _scriptProviders;
+        private readonly IEnumerable<ISeedScriptProvider> _seedProviders;
         private readonly IEnumerable<ISeedStrategyResolver> _strategyResolvers;
         private readonly ISeedExecutionStrategy _globalStrategy;
         private readonly ISeedExecutionStrategy _fallbackStrategy;
@@ -23,7 +24,7 @@ namespace DbReactor.Core.Services
         /// <summary>
         /// Initializes a new instance of SeedDiscoveryService
         /// </summary>
-        /// <param name="scriptProviders">Script providers to use for seed discovery</param>
+        /// <param name="scriptProviders">Script providers to use for seed discovery (legacy path)</param>
         /// <param name="strategyResolvers">Strategy resolvers for per-seed strategy determination</param>
         /// <param name="globalStrategy">Global strategy to apply to all seeds (overrides per-seed strategies)</param>
         /// <param name="fallbackStrategy">Fallback strategy when no other strategy can be determined</param>
@@ -34,6 +35,29 @@ namespace DbReactor.Core.Services
             ISeedExecutionStrategy fallbackStrategy = null)
         {
             _scriptProviders = scriptProviders ?? throw new ArgumentNullException(nameof(scriptProviders));
+            _seedProviders = Enumerable.Empty<ISeedScriptProvider>();
+            _strategyResolvers = strategyResolvers ?? Enumerable.Empty<ISeedStrategyResolver>();
+            _globalStrategy = globalStrategy;
+            _fallbackStrategy = fallbackStrategy ?? new RunOnceSeedStrategy();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of SeedDiscoveryService with new seed providers
+        /// </summary>
+        /// <param name="seedProviders">Seed providers that resolve strategy at discovery time</param>
+        /// <param name="scriptProviders">Legacy script providers (strategy resolved here)</param>
+        /// <param name="strategyResolvers">Strategy resolvers for legacy script providers</param>
+        /// <param name="globalStrategy">Global strategy to apply to all seeds (overrides per-seed strategies)</param>
+        /// <param name="fallbackStrategy">Fallback strategy when no other strategy can be determined</param>
+        public SeedDiscoveryService(
+            IEnumerable<ISeedScriptProvider> seedProviders,
+            IEnumerable<IScriptProvider> scriptProviders = null,
+            IEnumerable<ISeedStrategyResolver> strategyResolvers = null,
+            ISeedExecutionStrategy globalStrategy = null,
+            ISeedExecutionStrategy fallbackStrategy = null)
+        {
+            _seedProviders = seedProviders ?? Enumerable.Empty<ISeedScriptProvider>();
+            _scriptProviders = scriptProviders ?? Enumerable.Empty<IScriptProvider>();
             _strategyResolvers = strategyResolvers ?? Enumerable.Empty<ISeedStrategyResolver>();
             _globalStrategy = globalStrategy;
             _fallbackStrategy = fallbackStrategy ?? new RunOnceSeedStrategy();
@@ -46,20 +70,39 @@ namespace DbReactor.Core.Services
         /// <returns>Collection of seeds</returns>
         public async Task<IEnumerable<ISeed>> GetSeedsAsync(CancellationToken cancellationToken = default)
         {
-            var allScripts = new List<IScript>();
-            
+            var allSeeds = new List<ISeed>();
+
+            // New path: ISeedScriptProvider returns seeds with strategy already resolved
+            foreach (var seedProvider in _seedProviders)
+            {
+                var seeds = await seedProvider.GetSeedsAsync(cancellationToken);
+
+                // Global strategy overrides per-seed strategies for consistency with legacy path
+                if (_globalStrategy != null)
+                {
+                    allSeeds.AddRange(seeds.Select(s => new Seed(s.Name, s.Script, _globalStrategy, s.Hash)));
+                }
+                else
+                {
+                    allSeeds.AddRange(seeds);
+                }
+            }
+
+            // Legacy path: IScriptProvider returns raw scripts, strategy resolved here
+            // [Obsolete] Prefer ISeedScriptProvider for correct folder-based strategy resolution
             foreach (var provider in _scriptProviders)
             {
                 var scripts = await provider.GetScriptsAsync(cancellationToken);
-                allScripts.AddRange(scripts);
+                var seeds = scripts.Select(script => new Seed(
+                    script.Name,
+                    script,
+                    DetermineStrategy(script, script.Name),
+                    script.Hash
+                ));
+                allSeeds.AddRange(seeds);
             }
 
-            return allScripts.Select(script => new Seed(
-                script.Name,
-                script,
-                DetermineStrategy(script, script.Name),
-                script.Hash
-            ));
+            return allSeeds;
         }
 
         /// <summary>

--- a/DbReactor.Core/Services/SeedOrchestrator.cs
+++ b/DbReactor.Core/Services/SeedOrchestrator.cs
@@ -82,6 +82,12 @@ namespace DbReactor.Core.Services
                     return result;
                 }
 
+                // Sort by strategy priority: RunOnce (1) → RunIfChanged (2) → RunAlways (3)
+                // Stable sort preserves discovery order within same priority
+                seedsToExecute = seedsToExecute
+                    .OrderBy(s => SeedStrategyPriority.GetPriority(s.Strategy.Name))
+                    .ToList();
+
                 _configuration.LogProvider?.WriteInformation($"Found {seedsToExecute.Count} seed(s) to execute.");
 
                 // Execute each seed
@@ -141,13 +147,18 @@ namespace DbReactor.Core.Services
                     return result;
                 }
 
+                // Sort by strategy priority to match execution order: RunOnce (1) → RunIfChanged (2) → RunAlways (3)
+                // Stable sort preserves discovery order within same priority
+                var orderedSeeds = seeds
+                    .OrderBy(s => SeedStrategyPriority.GetPriority(s.Strategy.Name));
+
                 if (!databaseExists)
                 {
-                    await HandleNonExistentDatabasePreview(result, seeds);
+                    await HandleNonExistentDatabasePreview(result, orderedSeeds);
                 }
                 else
                 {
-                    await HandleExistingDatabasePreview(result, seeds, cancellationToken);
+                    await HandleExistingDatabasePreview(result, orderedSeeds, cancellationToken);
                 }
 
                 _configuration.LogProvider?.WriteInformation($"Seed preview completed. {result.Summary}");

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## License
 
-[Your License Here]
+MIT
 
 ---
 


### PR DESCRIPTION
…unAlways

Seeds were executing in wrong order — RunAlways scripts ran before RunOnce, causing failures when RunAlways seeds depended on reference data seeded by RunOnce scripts.

- Add ISeedScriptProvider abstraction to resolve strategy at the provider level

- Add SeedStrategyPriority constants for deterministic ordering

- Introduce FileSystemSeedProvider and EmbeddedSeedProvider implementations

- Sort seeds by strategy priority in SeedOrchestrator before execution

- Add unit tests for ordering, providers, and priority constants

- Update documentation to reflect new seeding architecture