### PR TITLE
feat: route SQL PRINT statements through ILogProvider

### DIFF
--- a/DbReactor.Core/Utilities/PathUtility.cs
+++ b/DbReactor.Core/Utilities/PathUtility.cs
@@ -207,5 +207,23 @@ namespace DbReactor.Core.Utilities
             
             return namespacePath.Substring(lastDotIndex + 1);
         }
+
+        /// <summary>
+        /// Returns the leaf segment of a namespace-style resource name,
+        /// after stripping known script extensions (.sql).
+        /// Suitable for log output and display purposes.
+        /// </summary>
+        public static string GetLeafName(string resourceName)
+        {
+            if (string.IsNullOrEmpty(resourceName))
+                return string.Empty;
+
+            var name = resourceName;
+            if (name.EndsWith(".sql", StringComparison.OrdinalIgnoreCase))
+                name = name.Substring(0, name.Length - 4);
+
+            int lastDot = name.LastIndexOf('.');
+            return lastDot >= 0 ? name.Substring(lastDot + 1) : name;
+        }
     }
 }

--- a/DbReactor.MSSqlServer.Tests/Execution/SqlServerScriptExecutorInfoMessageTests.cs
+++ b/DbReactor.MSSqlServer.Tests/Execution/SqlServerScriptExecutorInfoMessageTests.cs
@@ -1,0 +1,305 @@
+using DbReactor.Core.Abstractions;
+using DbReactor.Core.Execution;
+using DbReactor.Core.Logging;
+using DbReactor.Core.Models;
+using DbReactor.Core.Models.Scripts;
+using DbReactor.MSSqlServer.Execution;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Microsoft.Data.SqlClient;
+using Moq;
+using System.Data;
+
+namespace DbReactor.MSSqlServer.Tests.Execution;
+
+[TestFixture]
+public class SqlServerScriptExecutorInfoMessageTests
+{
+    private const string ValidConnectionString = "Server=localhost;Database=TestDB;Trusted_Connection=true;";
+
+    #region Constructor Backward Compatibility
+
+    [Test]
+    public void Constructor_WithNoLogProvider_ShouldCreateExecutorWithoutError()
+    {
+        // When
+        SqlServerScriptExecutor executor = new SqlServerScriptExecutor();
+
+        // Then
+        executor.Should().NotBeNull();
+    }
+
+    [Test]
+    public void Constructor_WithTimeoutOnly_ShouldCreateExecutorWithoutError()
+    {
+        // When
+        SqlServerScriptExecutor executor = new SqlServerScriptExecutor(TimeSpan.FromSeconds(30));
+
+        // Then
+        executor.Should().NotBeNull();
+    }
+
+    [Test]
+    public void Constructor_WithNullLogProvider_ShouldCreateExecutorWithoutError()
+    {
+        // When
+        SqlServerScriptExecutor executor = new SqlServerScriptExecutor(TimeSpan.FromSeconds(30), (ILogProvider)null);
+
+        // Then
+        executor.Should().NotBeNull();
+    }
+
+    #endregion
+
+    #region Constructor With Logger
+
+    [Test]
+    public void Constructor_WithLogProvider_ShouldCreateExecutorWithoutError()
+    {
+        // Given
+        Mock<ILogProvider> mockLogger = new Mock<ILogProvider>();
+
+        // When
+        SqlServerScriptExecutor executor = new SqlServerScriptExecutor(TimeSpan.FromSeconds(30), mockLogger.Object);
+
+        // Then
+        executor.Should().NotBeNull();
+    }
+
+    [Test]
+    public async Task ExecuteAsync_WithLogProvider_AndConnectionFailure_ShouldReturnFailedResult()
+    {
+        // Given
+        Mock<ILogProvider> mockLogger = new Mock<ILogProvider>();
+        SqlServerScriptExecutor executor = new SqlServerScriptExecutor(TimeSpan.FromSeconds(30), mockLogger.Object);
+        GenericScript script = new GenericScript("test.sql", "SELECT 1");
+        InvalidOperationException expectedException = new InvalidOperationException("Connection failed");
+        Mock<IConnectionManager> mockConnectionManager = new Mock<IConnectionManager>();
+
+        mockConnectionManager.Setup(cm => cm.ExecuteWithManagedConnectionAsync(
+            It.IsAny<Func<IDbConnection, Task>>(),
+            It.IsAny<CancellationToken>()))
+            .ThrowsAsync(expectedException);
+
+        // When
+        MigrationResult result = await executor.ExecuteAsync(script, mockConnectionManager.Object, CancellationToken.None);
+
+        // Then
+        using (new AssertionScope())
+        {
+            result.Should().NotBeNull();
+            result.Successful.Should().BeFalse();
+            result.Error.Should().Be(expectedException);
+        }
+    }
+
+    [Test]
+    public async Task ExecuteAsync_WithNullLogProvider_AndConnectionFailure_ShouldNotThrowNullReference()
+    {
+        // Given — null log provider triggers NullLogProvider fallback
+        SqlServerScriptExecutor executor = new SqlServerScriptExecutor(TimeSpan.FromSeconds(30), (ILogProvider)null);
+        GenericScript script = new GenericScript("test.sql", "SELECT 1");
+        InvalidOperationException expectedException = new InvalidOperationException("Connection failed");
+        Mock<IConnectionManager> mockConnectionManager = new Mock<IConnectionManager>();
+
+        mockConnectionManager.Setup(cm => cm.ExecuteWithManagedConnectionAsync(
+            It.IsAny<Func<IDbConnection, Task>>(),
+            It.IsAny<CancellationToken>()))
+            .ThrowsAsync(expectedException);
+
+        // When
+        MigrationResult result = await executor.ExecuteAsync(script, mockConnectionManager.Object, CancellationToken.None);
+
+        // Then — should fail gracefully, not throw NullReferenceException
+        using (new AssertionScope())
+        {
+            result.Should().NotBeNull();
+            result.Successful.Should().BeFalse();
+            result.Error.Should().Be(expectedException);
+            result.Error.Should().NotBeOfType<NullReferenceException>();
+        }
+    }
+
+    #endregion
+
+    #region InfoMessage Routing (Integration - requires SQL Server)
+
+    [Test]
+    public async Task ExecuteAsync_WithPrintStatement_ShouldRouteMessageToLogProvider()
+    {
+        // Given
+        if (!IsConnectionStringValid(ValidConnectionString))
+        {
+            Assert.Ignore("SQL Server not available — skipping integration test");
+            return;
+        }
+
+        Mock<ILogProvider> mockLogger = new Mock<ILogProvider>();
+        SqlServerScriptExecutor executor = new SqlServerScriptExecutor(TimeSpan.FromSeconds(30), mockLogger.Object);
+        GenericScript script = new GenericScript("print-test.sql", "PRINT 'hello from info message'");
+        DbReactor.MSSqlServer.Execution.DbReactor.MSSqlServer.Implementations.Execution.SqlServerConnectionManager connectionManager =
+            new DbReactor.MSSqlServer.Execution.DbReactor.MSSqlServer.Implementations.Execution.SqlServerConnectionManager(ValidConnectionString);
+
+        // When
+        MigrationResult result = await executor.ExecuteAsync(script, connectionManager, CancellationToken.None);
+
+        // Then
+        using (new AssertionScope())
+        {
+            result.Should().NotBeNull();
+            result.Successful.Should().BeTrue();
+            mockLogger.Verify(
+                l => l.WriteInformation(It.Is<string>(msg => msg.Contains("hello from info message")), It.IsAny<object[]>()),
+                Times.AtLeastOnce());
+        }
+    }
+
+    [Test]
+    public async Task ExecuteAsync_WithMultiplePrintStatements_ShouldRouteAllMessagesToLogProvider()
+    {
+        // Given
+        if (!IsConnectionStringValid(ValidConnectionString))
+        {
+            Assert.Ignore("SQL Server not available — skipping integration test");
+            return;
+        }
+
+        Mock<ILogProvider> mockLogger = new Mock<ILogProvider>();
+        SqlServerScriptExecutor executor = new SqlServerScriptExecutor(TimeSpan.FromSeconds(30), mockLogger.Object);
+        string scriptContent = @"
+PRINT 'message one'
+PRINT 'message two'
+PRINT 'message three'
+";
+        GenericScript script = new GenericScript("multi-print.sql", scriptContent);
+        DbReactor.MSSqlServer.Execution.DbReactor.MSSqlServer.Implementations.Execution.SqlServerConnectionManager connectionManager =
+            new DbReactor.MSSqlServer.Execution.DbReactor.MSSqlServer.Implementations.Execution.SqlServerConnectionManager(ValidConnectionString);
+
+        // When
+        MigrationResult result = await executor.ExecuteAsync(script, connectionManager, CancellationToken.None);
+
+        // Then
+        using (new AssertionScope())
+        {
+            result.Should().NotBeNull();
+            result.Successful.Should().BeTrue();
+            mockLogger.Verify(
+                l => l.WriteInformation(It.IsAny<string>(), It.IsAny<object[]>()),
+                Times.AtLeast(3));
+        }
+    }
+
+    [Test]
+    public async Task ExecuteAsync_WithPrintInBatchedScript_ShouldRouteMessageToLogProvider()
+    {
+        // Given
+        if (!IsConnectionStringValid(ValidConnectionString))
+        {
+            Assert.Ignore("SQL Server not available — skipping integration test");
+            return;
+        }
+
+        Mock<ILogProvider> mockLogger = new Mock<ILogProvider>();
+        SqlServerScriptExecutor executor = new SqlServerScriptExecutor(TimeSpan.FromSeconds(30), mockLogger.Object);
+        string scriptContent = @"
+PRINT 'batch one start'
+SELECT 1
+GO
+PRINT 'batch two start'
+SELECT 2
+";
+        GenericScript script = new GenericScript("batched-print.sql", scriptContent);
+        DbReactor.MSSqlServer.Execution.DbReactor.MSSqlServer.Implementations.Execution.SqlServerConnectionManager connectionManager =
+            new DbReactor.MSSqlServer.Execution.DbReactor.MSSqlServer.Implementations.Execution.SqlServerConnectionManager(ValidConnectionString);
+
+        // When
+        MigrationResult result = await executor.ExecuteAsync(script, connectionManager, CancellationToken.None);
+
+        // Then
+        using (new AssertionScope())
+        {
+            result.Should().NotBeNull();
+            result.Successful.Should().BeTrue();
+            mockLogger.Verify(
+                l => l.WriteInformation(It.Is<string>(msg => msg.Contains("batch one start")), It.IsAny<object[]>()),
+                Times.AtLeastOnce());
+            mockLogger.Verify(
+                l => l.WriteInformation(It.Is<string>(msg => msg.Contains("batch two start")), It.IsAny<object[]>()),
+                Times.AtLeastOnce());
+        }
+    }
+
+    [Test]
+    public async Task ExecuteAsync_WithRaiserrorInfoMessage_ShouldRouteMessageToLogProvider()
+    {
+        // Given
+        if (!IsConnectionStringValid(ValidConnectionString))
+        {
+            Assert.Ignore("SQL Server not available — skipping integration test");
+            return;
+        }
+
+        Mock<ILogProvider> mockLogger = new Mock<ILogProvider>();
+        SqlServerScriptExecutor executor = new SqlServerScriptExecutor(TimeSpan.FromSeconds(30), mockLogger.Object);
+        // RAISERROR with severity 0-10 routes through InfoMessage, not as an exception
+        GenericScript script = new GenericScript("raiserror-info.sql", "RAISERROR('informational message', 0, 1) WITH NOWAIT");
+        DbReactor.MSSqlServer.Execution.DbReactor.MSSqlServer.Implementations.Execution.SqlServerConnectionManager connectionManager =
+            new DbReactor.MSSqlServer.Execution.DbReactor.MSSqlServer.Implementations.Execution.SqlServerConnectionManager(ValidConnectionString);
+
+        // When
+        MigrationResult result = await executor.ExecuteAsync(script, connectionManager, CancellationToken.None);
+
+        // Then
+        using (new AssertionScope())
+        {
+            result.Should().NotBeNull();
+            result.Successful.Should().BeTrue();
+            mockLogger.Verify(
+                l => l.WriteInformation(It.Is<string>(msg => msg.Contains("informational message")), It.IsAny<object[]>()),
+                Times.AtLeastOnce());
+        }
+    }
+
+    [Test]
+    public async Task ExecuteAsync_WithNoLogProvider_AndPrintStatement_ShouldNotThrow()
+    {
+        // Given — default constructor uses NullLogProvider
+        if (!IsConnectionStringValid(ValidConnectionString))
+        {
+            Assert.Ignore("SQL Server not available — skipping integration test");
+            return;
+        }
+
+        SqlServerScriptExecutor executor = new SqlServerScriptExecutor();
+        GenericScript script = new GenericScript("print-null-logger.sql", "PRINT 'this should not crash'");
+        DbReactor.MSSqlServer.Execution.DbReactor.MSSqlServer.Implementations.Execution.SqlServerConnectionManager connectionManager =
+            new DbReactor.MSSqlServer.Execution.DbReactor.MSSqlServer.Implementations.Execution.SqlServerConnectionManager(ValidConnectionString);
+
+        // When
+        MigrationResult result = await executor.ExecuteAsync(script, connectionManager, CancellationToken.None);
+
+        // Then — NullLogProvider absorbs the message without throwing
+        using (new AssertionScope())
+        {
+            result.Should().NotBeNull();
+            result.Successful.Should().BeTrue();
+            result.Error.Should().BeNull();
+        }
+    }
+
+    #endregion
+
+    private static bool IsConnectionStringValid(string connectionString)
+    {
+        try
+        {
+            using SqlConnection connection = new SqlConnection(connectionString);
+            connection.Open();
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/DbReactor.MSSqlServer/Execution/SqlServerScriptExecutor.cs
+++ b/DbReactor.MSSqlServer/Execution/SqlServerScriptExecutor.cs
@@ -1,6 +1,8 @@
 using DbReactor.Core.Abstractions;
 using DbReactor.Core.Execution;
+using DbReactor.Core.Logging;
 using DbReactor.Core.Models;
+using DbReactor.Core.Utilities;
 using DbReactor.MSSqlServer.Constants;
 using DbReactor.MSSqlServer.Utilities;
 using Microsoft.Data.SqlClient;
@@ -17,12 +19,19 @@ namespace DbReactor.MSSqlServer.Execution
     public class SqlServerScriptExecutor : IScriptExecutor
     {
         private readonly TimeSpan _commandTimeout;
+        private readonly Func<ILogProvider> _logProviderFactory;
 
-        public SqlServerScriptExecutor() : this(SqlServerConstants.Defaults.CommandTimeout) { }
+        public SqlServerScriptExecutor() : this(SqlServerConstants.Defaults.CommandTimeout, (ILogProvider)null) { }
 
-        public SqlServerScriptExecutor(TimeSpan commandTimeout)
+        public SqlServerScriptExecutor(TimeSpan commandTimeout) : this(commandTimeout, (ILogProvider)null) { }
+
+        public SqlServerScriptExecutor(TimeSpan commandTimeout, ILogProvider logProvider)
+            : this(commandTimeout, logProvider != null ? (Func<ILogProvider>)(() => logProvider) : null) { }
+
+        public SqlServerScriptExecutor(TimeSpan commandTimeout, Func<ILogProvider> logProviderFactory)
         {
             _commandTimeout = commandTimeout;
+            _logProviderFactory = logProviderFactory ?? (() => new NullLogProvider());
         }
 
         public async Task<MigrationResult> ExecuteAsync(IScript script, IConnectionManager connectionManager, CancellationToken cancellationToken = default)
@@ -72,7 +81,7 @@ namespace DbReactor.MSSqlServer.Execution
             if (SqlUtilities.IsEfTransactionScript(scriptContent))
             {
                 string scriptWithoutGo = SqlUtilities.RemoveGoStatements(scriptContent);
-                await ExecuteNonQueryAsync(scriptWithoutGo, connectionManager, cancellationToken);
+                await ExecuteNonQueryAsync(scriptWithoutGo, connectionManager, PathUtility.GetLeafName(script.Name), cancellationToken);
                 return;
             }
 
@@ -82,36 +91,72 @@ namespace DbReactor.MSSqlServer.Execution
             await connectionManager.ExecuteWithManagedConnectionAsync(async connection =>
             {
                 SqlConnection sqlConnection = (SqlConnection)connection;
-                if (hasManualTransactions)
+                sqlConnection.FireInfoMessageEventOnUserErrors = true;
+                string shortName = PathUtility.GetLeafName(script.Name);
+                SqlInfoMessageEventHandler infoHandler = (sender, e) =>
                 {
-                    await ExecuteBatchesAsync(batches, sqlConnection, null, cancellationToken);
+                    ILogProvider logProvider = _logProviderFactory();
+                    foreach (SqlError error in e.Errors)
+                    {
+                        logProvider.WriteInformation($"[{shortName}] {error.Message}");
+                    }
+                };
+                sqlConnection.InfoMessage += infoHandler;
+                try
+                {
+                    if (hasManualTransactions)
+                    {
+                        await ExecuteBatchesAsync(batches, sqlConnection, null, cancellationToken);
+                    }
+                    else
+                    {
+                        using SqlTransaction transaction = sqlConnection.BeginTransaction();
+                        try
+                        {
+                            await ExecuteBatchesAsync(batches, sqlConnection, transaction, cancellationToken);
+                            transaction.Commit();
+                        }
+                        catch
+                        {
+                            try { transaction.Rollback(); } catch { }
+                            throw;
+                        }
+                    }
                 }
-                else
+                finally
                 {
-                    using SqlTransaction transaction = sqlConnection.BeginTransaction();
-                    try
-                    {
-                        await ExecuteBatchesAsync(batches, sqlConnection, transaction, cancellationToken);
-                        transaction.Commit();
-                    }
-                    catch
-                    {
-                        try { transaction.Rollback(); } catch { }
-                        throw;
-                    }
+                    sqlConnection.InfoMessage -= infoHandler;
                 }
             }, cancellationToken);
         }
 
-        private async Task ExecuteNonQueryAsync(string sql, IConnectionManager connectionManager, CancellationToken cancellationToken)
+        private async Task ExecuteNonQueryAsync(string sql, IConnectionManager connectionManager, string scriptName, CancellationToken cancellationToken)
         {
             await connectionManager.ExecuteWithManagedConnectionAsync(async connection =>
             {
-                using SqlCommand command = new SqlCommand(sql, (SqlConnection)connection)
+                SqlConnection sqlConnection = (SqlConnection)connection;
+                sqlConnection.FireInfoMessageEventOnUserErrors = true;
+                SqlInfoMessageEventHandler infoHandler = (sender, e) =>
                 {
-                    CommandTimeout = (int)_commandTimeout.TotalSeconds
+                    ILogProvider logProvider = _logProviderFactory();
+                    foreach (SqlError error in e.Errors)
+                    {
+                        logProvider.WriteInformation($"[{scriptName}] {error.Message}");
+                    }
                 };
-                await command.ExecuteNonQueryAsync(cancellationToken);
+                sqlConnection.InfoMessage += infoHandler;
+                try
+                {
+                    using SqlCommand command = new SqlCommand(sql, sqlConnection)
+                    {
+                        CommandTimeout = (int)_commandTimeout.TotalSeconds
+                    };
+                    await command.ExecuteNonQueryAsync(cancellationToken);
+                }
+                finally
+                {
+                    sqlConnection.InfoMessage -= infoHandler;
+                }
             }, cancellationToken);
         }
 

--- a/DbReactor.MSSqlServer/Extensions/SqlServerExtensions.cs
+++ b/DbReactor.MSSqlServer/Extensions/SqlServerExtensions.cs
@@ -1,5 +1,6 @@
 using DbReactor.Core.Configuration;
 using DbReactor.Core.Extensions;
+using DbReactor.Core.Logging;
 using DbReactor.Core.Seeding.Strategies;
 using DbReactor.MSSqlServer.Constants;
 using DbReactor.MSSqlServer.Execution;
@@ -59,7 +60,7 @@ namespace DbReactor.MSSqlServer.Extensions
         /// <returns>The configuration for method chaining</returns>
         public static DbReactorConfiguration UseSqlServerExecutor(this DbReactorConfiguration config, TimeSpan? commandTimeout = null)
         {
-            config.ScriptExecutor = new SqlServerScriptExecutor(commandTimeout ?? SqlServerConstants.Defaults.CommandTimeout);
+            config.ScriptExecutor = new SqlServerScriptExecutor(commandTimeout ?? SqlServerConstants.Defaults.CommandTimeout, () => config.LogProvider ?? new NullLogProvider());
             return config;
         }
 
@@ -102,7 +103,7 @@ namespace DbReactor.MSSqlServer.Extensions
         public static DbReactorConfiguration UseSqlServerCommandTimeout(this DbReactorConfiguration config, TimeSpan timeout)
         {
             // Update the existing executor with the new timeout
-            config.ScriptExecutor = new SqlServerScriptExecutor(timeout);
+            config.ScriptExecutor = new SqlServerScriptExecutor(timeout, config.LogProvider);
             return config;
         }
 

--- a/DbReactor.MSSqlServer/README.md
+++ b/DbReactor.MSSqlServer/README.md
@@ -534,6 +534,55 @@ var connectionString = "Server=localhost;Database=MyApp;Integrated Security=true
 var connectionString = "Server=localhost;Database=MyApp;User Id=dbuser;Password=password;MultipleActiveResultSets=true;";
 ```
 
+## Script Output Logging
+
+SQL Server `PRINT` statements and low-severity `RAISERROR` messages (severity 0-10) from your scripts are automatically captured and routed through the configured `ILogProvider` during execution.
+
+This allows you to add diagnostic output to your migration and seed scripts:
+
+```sql
+-- In your migration or seed script
+PRINT 'Creating rules schema and tables...'
+
+CREATE SCHEMA [rules];
+CREATE TABLE [rules].[RuleSets] (
+    RuleSetId INT PRIMARY KEY IDENTITY(1,1),
+    Name NVARCHAR(100) NOT NULL
+);
+
+PRINT 'Rules schema created successfully'
+```
+
+When using `UseConsoleLogging()`, this produces:
+
+```
+[INFO] 2026-06-03 09:58:03 - Creating rules schema and tables...
+[INFO] 2026-06-03 09:58:03 - Successfully executed script: M006_RulesInit
+[INFO] 2026-06-03 09:58:03 - Rules schema created successfully
+```
+
+### Requirements
+
+- Configure a log provider (e.g., `.UseConsoleLogging()`) in your `DbReactorConfiguration`
+- No additional configuration needed — output capture is automatic when a log provider is configured
+
+### Custom Log Provider
+
+Implement `ILogProvider` to route script output to your preferred logging framework:
+
+```csharp
+public class SerilogProvider : ILogProvider
+{
+    public void WriteInformation(string message) => Log.Information(message);
+    public void WriteError(string message) => Log.Error(message);
+    public void WriteWarning(string message) => Log.Warning(message);
+}
+
+var config = new DbReactorConfiguration()
+    .UseSqlServer(connectionString)
+    .UseLogProvider(new SerilogProvider());
+```
+
 ## Best Practices
 
 1. **Use Transactions**: Each migration runs in its own transaction

--- a/DbReactor.RunTest/Program.cs
+++ b/DbReactor.RunTest/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main(string[] args)
     {
-        string connectionString = "Server=localhost;Database=DbReactorTest;Trusted_Connection=True;TrustServerCertificate=true;MultipleActiveResultSets=true;";
+        string connectionString = "Server=(localdb)\\db;Database=DbReactorTest;Trusted_Connection=True;TrustServerCertificate=true;MultipleActiveResultSets=true;";
 
 
         DbReactorConfiguration config = new DbReactorConfiguration()

--- a/DbReactor.RunTest/Scripts/upgrades/20250714/M006_RulesInit.sql
+++ b/DbReactor.RunTest/Scripts/upgrades/20250714/M006_RulesInit.sql
@@ -1,3 +1,6 @@
+PRINT 'Creating rules schema and tables...'
+GO
+
 IF OBJECT_ID(N'[__EFMigrationsHistory]') IS NULL
 BEGIN
     CREATE TABLE [__EFMigrationsHistory] (

--- a/DbReactor.RunTest/Seeds/run-always/SRA1_UpdateStatistics.sql
+++ b/DbReactor.RunTest/Seeds/run-always/SRA1_UpdateStatistics.sql
@@ -1,6 +1,8 @@
 -- Maintenance script that runs every time
 -- Uses folder structure to determine strategy (run-always)
 
+PRINT 'DbReactor: Starting statistics update...'
+
 -- Update table statistics
 UPDATE STATISTICS Users
 UPDATE STATISTICS Products  
@@ -15,3 +17,5 @@ BEGIN
     -- Additional maintenance for production environments
     PRINT 'Production maintenance completed'
 END
+
+PRINT 'DbReactor: Statistics update complete.'


### PR DESCRIPTION
- Subscribe to SqlConnection.InfoMessage in SqlServerScriptExecutor
- Use Func<ILogProvider> factory for lazy logger resolution (fixes ordering issue where UseConsoleLogging() is called after UseSqlServer())
- Set FireInfoMessageEventOnUserErrors = true for immediate delivery
- Prefix PRINT output with [ScriptName] for attribution
- Add PathUtility.GetLeafName() for extracting short script names
- Add InfoMessage integration tests
- Add PRINT statements to RunTest scripts for demonstration
- Document Script Output Logging in MSSqlServer README